### PR TITLE
Draft PR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ If you run with `--create-prs` again, `pr-train` will only override the Table of
 
 **Pro-tip**: If you want to udpate the ToCs in your GitHub PRs, just update the PR titles and re-run pr train with `--create-prs` - it will do the right thing.
 
+### Draft PRs
+
+To create PRs in draft mode ([if your repo allows](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)),
+pass the `-d` or `--draft` argument on the command line (instead of, or in addition to, `-c`/`--create-prs`).
+
+You can also configure PRs to be created in draft mode by default if you add the following section to your `.pr-train.yml` file:
+
+```yaml
+prs:
+  draft-by-default: true
+
+trains:
+  # etc
+```
+
+Specifying this option will allow you to omit the `-d`/`--draft` parameter (though you still need to specify `-c`/`--create-prs`) when you want to create/update PRs.
+
 ## Example with explanation
 
 You finished coding a feature and now you have a patch that is over 1000 SLOCs long. That's a big patch. As a good citizen, you want to split the diff into multiple PRs, e.g.:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you run with `--create-prs` again, `pr-train` will only override the Table of
 ### Draft PRs
 
 To create PRs in draft mode ([if your repo allows](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)),
-pass the `-d` or `--draft` argument on the command line (instead of, or in addition to, `-c`/`--create-prs`).
+pass the `-d` or `--draft` argument on the command line (in addition to `-c`/`--create-prs`).
 
 You can also configure PRs to be created in draft mode by default if you add the following section to your `.pr-train.yml` file:
 

--- a/cfg_template.yml
+++ b/cfg_template.yml
@@ -1,6 +1,11 @@
 prs:
   # Uncomment this if you use a different name for your default branch (e.g. "main" instead of "master")
   # main-branch-name: main
+  #
+  # Create new PRs in draft mode by default. This will prevent them from notifying anybody
+  # until you are ready. This option can be overridden on the command line using the
+  # -d/--draft  or --no-draft options, which set draft mode to true or false, respectively.
+  draft-by-default: true
 
 trains:
   # This is an example. This PR train would have 4 branches plus 1 "combined" branch to run tests etc on.

--- a/cfg_template.yml
+++ b/cfg_template.yml
@@ -2,10 +2,10 @@ prs:
   # Uncomment this if you use a different name for your default branch (e.g. "main" instead of "master")
   # main-branch-name: main
   #
-  # Create new PRs in draft mode by default. This will prevent them from notifying anybody
-  # until you are ready. This option can be overridden on the command line using the
+  # Uncomment to create new PRs in draft mode by default. This will prevent them from notifying anybody
+  # (including CODEOWNERS) until you are ready. This option can be overridden on the command line using the
   # -d/--draft  or --no-draft options, which set draft mode to true or false, respectively.
-  draft-by-default: true
+  # draft-by-default: true
 
 trains:
   # This is an example. This PR train would have 4 branches plus 1 "combined" branch to run tests etc on.

--- a/github.js
+++ b/github.js
@@ -95,6 +95,7 @@ function checkAndReportInvalidBaseError(e, base) {
  * @param {simpleGit.SimpleGit} sg
  * @param {Array.<string>} allBranches
  * @param {string} combinedBranch
+ * @param {boolean} draft
  * @param {string} remote
  * @param {string} baseBranch
  */
@@ -102,6 +103,7 @@ async function ensurePrsExist({
   sg,
   allBranches,
   combinedBranch,
+  draft,
   remote = DEFAULT_REMOTE,
   baseBranch = DEFAULT_BASE_BRANCH
 }) {
@@ -131,8 +133,10 @@ async function ensurePrsExist({
     body: '',
   });
 
+  const prText = draft ? 'draft PR' : 'PR';
+
   console.log();
-  console.log('This will create (or update) PRs for the following branches:');
+  console.log(`This will create (or update) ${prText}s for the following branches:`);
   await allBranches.reduce(async (memo, branch) => {
     await memo;
     const {
@@ -185,9 +189,10 @@ async function ensurePrsExist({
         base,
         title,
         body,
+        draft,
       };
       const baseMessage = base === baseBranch ? colors.dim(` (against ${base})`) : '';
-      process.stdout.write(`Creating PRs for branch "${branch}"${baseMessage}...`);
+      process.stdout.write(`Creating ${prText} for branch "${branch}"${baseMessage}...`);
       try {
         prResponse = (await ghRepo.prAsync(payload))[0];
       } catch (e) {

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ async function main() {
   }
 
   const defaultBase = getConfigOption(ymlConfig, 'prs.main-branch-name') || DEFAULT_BASE_BRANCH;
-  const draftByDefault = getConfigOption(ymlConfig, 'prs.draft-by-default');
+  const draftByDefault = !!getConfigOption(ymlConfig, 'prs.draft-by-default');
 
   program
     .version(package.version)
@@ -228,13 +228,10 @@ async function main() {
     .option('-f, --force', 'Force push to remote')
     .option('--push-merged', 'Push all branches (including those that have already been merged into the base branch)')
     .option('--remote <remote>', 'Set remote to push to. Defaults to "origin"')
-    .option('-b, --base <base>', `Specify the base branch to use for the first and combined PRs.`, defaultBase);
-  if (draftByDefault) {
-    program.option('--no-draft', 'Do not create PRs in draft mode (override default)');
-  } else {
-    program.option('-d, --draft', 'Create PRs in draft mode')
-  }
-  program.option('-c, --create-prs', 'Create GitHub PRs from your train branches');
+    .option('-b, --base <base>', `Specify the base branch to use for the first and combined PRs.`, defaultBase)
+    .option('-d, --draft', 'Create PRs in draft mode', draftByDefault)
+    .option('--no-draft', 'Do not create PRs in draft mode', !draftByDefault)
+    .option('-c, --create-prs', 'Create GitHub PRs from your train branches');
 
   program.on('--help', () => {
     console.log('');

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,9 @@
       }
     },
     "commander": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "colors": "^1.2.1",
-    "commander": "^2.15.0",
+    "commander": "^3.0.2",
     "figlet": "^1.2.0",
     "inquirer": "^6.2.1",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
<pr-train-toc>

|     | PR | Description                                          |
| --- | -- | ---------------------------------------------------- |
|     | #30 | Added ability to customise the base branch          |
| 👉  | #3 | Draft PR support                                     |
|     | #4 | Cater for body being nullish or empty                |
|     | #5 | Putting the table back in 'table of contents'!       |
|     | #6 | Added support to print links to PRs in terminal      |
|     | #7 | Work when remote URL doesn't have .git suffix        |
|     | #31 | **[combined branch]**                               |

</pr-train-toc>

## Which problem does this PR solve?

I personally have found that the PRs created by `pr-train` are often not ready to be seen by others on the team yet.

I regularly find myself having to add the following:
* A good PR description (aside from the ToC)
* A common pre-amble for each PR in the chain to provide context for the entire chain of changes
* A self-review to explain my thinking in some places
* Hand-picked reviewers

Thus, utilizing the ability to create draft PRs, which suppress notifications to code owners and others via Slack/email is handy until I have added all those details.

I would go so far as to say that I wish for the tool to always create draft PRs unless I override this behaviour.

## Main changes

Added a command-line option, `--draft`, to create PRs in draft mode.

Added a `prs.draft-by-default` setting to the `.pr-train.yml` config file to enable draft PRs to be the default. In this case, the command-line option becomes `--no-draft` to override the default behaviour on a per-command basis.

## Related documents/resources

[Create a pull request](https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#create-a-pull-request) GitHub REST API docs.

## Suggested CR ordering of files?

1. `cfg_template.yml`
2. `README.md`
3. `github.js`
4. `index.js`

## How I tested it works

I tested the following scenarios:

1. No `draft-by-default` setting in config file, no `--draft` command-line flag set. PRs created in non-draft status, maintaining the current behaviour.
2. `draft-by-default: true` setting in config file, no `--draft` command-line flag set. PRs created in draft status, which is correct.
3. `draft-by-default: true` setting in config file, `--no-draft` command-line flag set. PRs created in non-draft status, which is correct.
4. No `draft-by-default` setting in config file, `--draft` command-line flag set. PRs created in draft status, which is correct.
