### PR TITLE
Added support to print links to PRs in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ You can override the base branch to use when creating PRs by passing the `--base
 over the main branch specified in the config file.
 
 e.g. `git pr-train -p -c -b feat/my-feature-base`
+
+## Print the PR links to the terminal
+
+To have the command output include a link to the PR that was created or updated,
+simply add `print-urls: true` to the `prs` section of the config file.

--- a/cfg_template.yml
+++ b/cfg_template.yml
@@ -6,6 +6,9 @@ prs:
   # (including CODEOWNERS) until you are ready. This option can be overridden on the command line using the
   # -d/--draft  or --no-draft options, which set draft mode to true or false, respectively.
   # draft-by-default: true
+  #
+  # Print out the links to the terminal for the created/updated PRs (default false)
+  # print-urls: true
 
 trains:
   # This is an example. This PR train would have 4 branches plus 1 "combined" branch to run tests etc on.

--- a/github.js
+++ b/github.js
@@ -240,7 +240,7 @@ async function ensurePrsExist({
       body: `${newBody}`,
     });
     const prLink = get(updateResponse, '0._links.html.href', colors.yellow('Could not get URL'));
-    console.log(emoji.get('white_check_mark') + printLinks ? ` (${prLink})` : '');
+    console.log(emoji.get('white_check_mark') + (printLinks ? ` (${prLink})` : ''));
   }, Promise.resolve());
 }
 

--- a/github.js
+++ b/github.js
@@ -101,7 +101,7 @@ function checkAndReportInvalidBaseError(e, base) {
  * @param {boolean} draft
  * @param {string} remote
  * @param {string} baseBranch
- * @param {'text'|'table'} format
+ * @param {boolean} printLinks
  */
 async function ensurePrsExist({
   sg,
@@ -110,6 +110,7 @@ async function ensurePrsExist({
   draft,
   remote = DEFAULT_REMOTE,
   baseBranch = DEFAULT_BASE_BRANCH,
+  printLinks = false
 }) {
   //const allBranches = combinedBranch ? sortedBranches.concat(combinedBranch) : sortedBranches;
   const octoClient = octo.client(readGHKey());
@@ -234,11 +235,12 @@ async function ensurePrsExist({
     const navigation = constructTrainNavigation(prDict, branch, combinedBranch);
     const newBody = upsertNavigationInBody(navigation, body);
     process.stdout.write(`Updating PR for branch ${branch}...`);
-    await ghPr.updateAsync({
+    const updateResponse = await ghPr.updateAsync({
       title,
       body: `${newBody}`,
     });
-    console.log(emoji.get('white_check_mark'));
+    const prLink = get(updateResponse, '0._links.html.href', colors.yellow('Could not get URL'));
+    console.log(emoji.get('white_check_mark') + printLinks ? ` (${prLink})` : '');
   }, Promise.resolve());
 }
 

--- a/index.js
+++ b/index.js
@@ -326,6 +326,7 @@ async function main() {
       remote: program.remote,
       draft,
       baseBranch,
+      printLinks: getConfigOption(ymlConfig, 'prs.print-urls'),
     });
     return;
   }


### PR DESCRIPTION
<pr-train-toc>

|     | PR | Description                                       |
| --- | -- | ------------------------------------------------- |
|     | #30 | Added ability to customise the base branch       |
|     | #3 | Fixed bug where branches were always being pushed |
|     | #4 | Cater for body being nullish or empty             |
|     | #5 | Putting the table back in 'table of contents'!    |
| 👉  | #6 | Added support to print links to PRs in terminal   |
|     | #7 | Work when remote URL doesn't have .git suffix     |
|     | #31 | **[combined branch]** Combined changes           |

</pr-train-toc>

## Which problem does this PR solve?

Fixes #9.

## Main changes

Adds a new config option, `prs.print-urls`, to the `.pr-train.yml` config file. If `true`, the URL is shown after the ✅ for the update PRs logs.

## How I tested it works

Tested locally using `npm link`.