### PR TITLE
Work when remote URL doesn't have .git suffix

### DIFF
--- a/github.js
+++ b/github.js
@@ -156,7 +156,7 @@ async function ensurePrsExist({
     process.exit(0);
   }
 
-  const nickAndRepo = remoteUrl.match(/github\.com[/:](.*)\.git/)[1];
+  const nickAndRepo = remoteUrl.match(/github\.com[/:](.*)/)[1].replace(/\.git$/, '');
   if (!nickAndRepo) {
     console.log(`I could not parse your remote ${remote} repo URL`.red);
     process.exit(4);


### PR DESCRIPTION
<pr-train-toc>

|     | PR | Description                                       |
| --- | -- | ------------------------------------------------- |
|     | #30 | Added ability to customise the base branch       |
|     | #3 | Fixed bug where branches were always being pushed |
|     | #4 | Cater for body being nullish or empty             |
|     | #5 | Putting the table back in 'table of contents'!    |
|     | #6 | Added support to print links to PRs in terminal   |
| 👉  | #7 | Work when remote URL doesn't have .git suffix     |
|     | #31 | **[combined branch]** Combined changes           |

</pr-train-toc>

## Which problem does this PR solve?

I discovered when I was testing on [my fork](https://github.com/greglockwood/pr-train), which had a git remote URL of `https://github.com/greglockwood/pr-train`, without the `.git` extension, that the current code incorrectly assumed that the remote URL ended in `.git`.

## Main changes

Tweaked the code to not require the `.git` extension when extracting the nickname and repo (but remove it if it is there).

## How I tested it works

I managed to use `pr-train` on my fork (at least initially). It doesn't seem to really support chains of PRs across forks.
